### PR TITLE
feat(gateway): add  JWT security and auth routing to the API Gateway

### DIFF
--- a/backend/auth-service/src/main/java/com/mazad/auth/controller/UserController.java
+++ b/backend/auth-service/src/main/java/com/mazad/auth/controller/UserController.java
@@ -32,21 +32,21 @@ import lombok.RequiredArgsConstructor;
 
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/auth/")
 @RequiredArgsConstructor
 public class UserController {
     public final UserService userService;
     @Value("${auth.refresh-token-validity-days:4}")
     long    refreshValidity;
 
-    @PostMapping("auth/register")
+    @PostMapping("register")
     public UserResponseDTO adddUser(
         @RequestBody @Validated(UserRequestDTO.OnRegister.class) UserRequestDTO userRequest
     ) {
         return userService.addUser(userRequest);
     }
 
-    @PostMapping("auth/login")
+    @PostMapping("login")
     public ResponseEntity<LoginResponseDto> userLogin(
         @RequestBody @Validated(UserRequestDTO.OnLogin.class) UserRequestDTO userRequest,
         @CookieValue(name="refresh_token", required=false) String refreshToken
@@ -62,7 +62,7 @@ public class UserController {
                             .httpOnly(true)
                             .sameSite("Strict")
                             .secure(false) // true for HTTPS on production
-                            .path("/api/auth")
+                            .path("/api/v1/auth/")
                             .maxAge(Duration.ofDays(refreshValidity))
                             .build();
         loginResponse = LoginResponseDto
@@ -77,7 +77,7 @@ public class UserController {
                         .body(loginResponse);
     }
     
-    @PostMapping("/auth/logout")
+    @PostMapping("logout")
     public ResponseEntity<String> userLogout(
         @CookieValue(name = "refresh_token", required=false) String refreshToken
     ){
@@ -94,7 +94,7 @@ public class UserController {
                             .body("User Logout");
     }
 
-    @PostMapping("auth/refresh")
+    @PostMapping("refresh")
     public String  refresh(
         @CookieValue(name="refresh_token", required=false) String refreshToken
     ){

--- a/backend/auth-service/src/main/java/com/mazad/auth/security/SecurityConfig.java
+++ b/backend/auth-service/src/main/java/com/mazad/auth/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sessionManager -> sessionManager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> 
-                    auth.requestMatchers("/api/auth/login", "/api/auth/register", "/api/auth/refresh").permitAll()
+                    auth.requestMatchers("/auth/login", "/auth/register", "/auth/refresh", "/auth/logout").permitAll()
                         .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated())
                 .build();

--- a/backend/auth-service/src/main/resources/application.properties
+++ b/backend/auth-service/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=auth-service
 
 server.port=${AUTH_SERVER_PORT:9000}
 
-spring.datasource.url=${DB_URL}/${AUTH_DB_NAME:auth-db}
+spring.datasource.url=${DB_URL}/${AUTH_DB_NAME}
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 
@@ -12,5 +12,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.show-sql=true
 
 auth.secret-key=${AUTH_SECRET_KEY}
-auth.access-token-validity-min=${AUTH_TOKEN_MIN:15}
-auth.refresh-token-validity-days=${AUTH_TOKEN_DAY:4}
+auth.access-token-validity-min=${ACCESS_TOKEN_MIN:15}
+auth.refresh-token-validity-days=${REFRESH_TOKEN_DAY:4}

--- a/backend/mazad-gateway/pom.xml
+++ b/backend/mazad-gateway/pom.xml
@@ -50,6 +50,31 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.13.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.13.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.13.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+        
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/auth/AuthenticationFilter.java
+++ b/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/auth/AuthenticationFilter.java
@@ -1,0 +1,108 @@
+package com.mazad.mazadgateway.auth;
+
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationFilter implements GlobalFilter, Ordered{
+
+    private final JwtUtil           jwtUtil;
+    private final ObjectMapper      mapper;
+    
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest  request = exchange.getRequest();
+
+        if (RouterValidator.isSecured.test(request)){
+
+            if (isAuthMissing(request))
+                return onError(exchange, "Authorization header is missing", HttpStatus.UNAUTHORIZED);
+            String token = getAccessToken(request);
+
+            if (token == null || token.isEmpty() || !token.startsWith("Bearer "))
+                return onError(exchange, "Invalid Access Token", HttpStatus.UNAUTHORIZED);
+            token = token.substring(7);
+
+            try {
+                String userId = jwtUtil.extractUserId(token);
+                ServerHttpRequest modifiedRequest = request
+                                                        .mutate()
+                                                        .header("X-User-Id", userId)
+                                                        .build();
+                return chain.filter(exchange.mutate().request(modifiedRequest).build());
+                
+            } catch (ExpiredJwtException e) {
+                return onError(exchange, "Token has expired", HttpStatus.UNAUTHORIZED);
+            }catch (Exception e){
+                return onError(exchange, "Invalid Access Token", HttpStatus.UNAUTHORIZED);
+            }
+        }
+        return chain.filter(exchange);
+    }
+    
+    
+    private boolean isAuthMissing(ServerHttpRequest request){
+        return !request.getHeaders().containsHeader(HttpHeaders.AUTHORIZATION);
+    }
+
+    private String getAccessToken(ServerHttpRequest request){
+        return request
+                    .getHeaders()
+                    .getFirst(HttpHeaders.AUTHORIZATION);
+    }
+
+
+    private Mono<Void> onError(ServerWebExchange exchange, String errMessage, HttpStatus status){
+        ServerHttpResponse response;
+        Map<String, Object> errorDetails = new HashMap<>();
+        
+        response = exchange.getResponse();
+        response.setStatusCode(status);
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        
+        errorDetails.put("timestamp", Instant.now().toString());
+        errorDetails.put("status", status.value());
+        errorDetails.put("error", status.getReasonPhrase());
+        errorDetails.put("message", errMessage);
+        errorDetails.put("path", exchange.getRequest().getPath().toString());
+        
+        try{
+            byte[] errorBytes = mapper.writeValueAsBytes(errorDetails);
+            DataBuffer buffer = response.bufferFactory().wrap(errorBytes);
+            return response.writeWith(Mono.just(buffer));
+            
+        }catch(JacksonException e){
+            response.setComplete();
+        }
+        
+        return response.setComplete();
+    }
+
+
+    @Override
+    public int getOrder(){
+        return -1;
+    }
+}

--- a/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/auth/JwtUtil.java
+++ b/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/auth/JwtUtil.java
@@ -1,0 +1,43 @@
+package com.mazad.mazadgateway.auth;
+
+import java.util.Base64;
+import java.util.function.Function;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtUtil {
+    @Value("${auth.secrets.jwt-secret-key}")
+    private String secretKey;
+
+    
+    
+    public String extractUserId(String token){
+        return extractClaim(token, claims -> claims.get("userId", String.class));
+    }
+    
+    private <T> T extractClaim(String token, Function<Claims, T> claimResolver){
+        final Claims claims = extractAllClaims(token);
+        return claimResolver.apply(claims);
+    }
+    
+    private Claims extractAllClaims(String token){
+        return Jwts.parser()
+            .verifyWith(getSigingKey(secretKey))
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    private SecretKey getSigingKey(String secretKey){
+       byte[] key= Base64.getDecoder().decode(secretKey);
+       return Keys.hmacShaKeyFor(key);
+    }
+}

--- a/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/auth/RouterValidator.java
+++ b/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/auth/RouterValidator.java
@@ -1,0 +1,23 @@
+package com.mazad.mazadgateway.auth;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RouterValidator {
+    private RouterValidator(){}
+
+    public static final List<String> openApiEndPoints = List.of(
+        "/api/v1/auth/login",
+        "/api/v1/auth/register",
+        "/api/v1/auth/refresh"
+    );
+
+    public static final Predicate<ServerHttpRequest> isSecured = 
+                                request -> openApiEndPoints
+                                            .stream()
+                                            .noneMatch(uri -> request.getURI().getPath().contains(uri));
+}

--- a/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/routes/AuthRoutesConfig.java
+++ b/backend/mazad-gateway/src/main/java/com/mazad/mazadgateway/routes/AuthRoutesConfig.java
@@ -1,0 +1,21 @@
+package com.mazad.mazadgateway.routes;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AuthRoutesConfig {
+
+    @Bean
+    public RouteLocator authRouteLocator(RouteLocatorBuilder routeBuilder){
+        return routeBuilder.routes()
+                            .route("auth-service-route", r -> r
+                                    .path("/api/v1/auth/**")
+                                    .filters(f -> f.stripPrefix(2))
+                                    .uri("http://auth-service:9000")
+                            )
+                            .build();
+    }
+}

--- a/backend/mazad-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/mazad-gateway/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,12 @@
+{"properties": [
+  {
+    "name": "auth.secrets.jwt-secret-key",
+    "type": "java.lang.String",
+    "description": "A description for 'auth.secrets.jwt-secret-key'"
+  },
+  {
+    "name": "auth.server.port",
+    "type": "java.lang.String",
+    "description": "A description for 'auth.server.port'"
+  }
+]}

--- a/backend/mazad-gateway/src/main/resources/application.yml
+++ b/backend/mazad-gateway/src/main/resources/application.yml
@@ -1,3 +1,14 @@
 spring:
   application:
     name: mazad-gateway
+  config:
+    import: optional:file:../../.env[.properties]
+
+
+    
+auth:
+    secrets:
+      jwt-secret-key: ${AUTH_SECRET_KEY}
+    server:
+        port: ${AUTH_SERVER_PORT}
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,14 @@ services:
     environment:
       - SPRING_DATA_REDIS_HOST=${GATEWAY_REDIS_HOST}
       - SPRING_DATA_REDIS_PORT=${GATEWAY_REDIS_PORT}
+      - AUTH_SECRET_KEY=${AUTH_SECRET_KEY}
+      # - AUTH_SERVER_PORT=${AUTH_SERVER_PORT}
       
     ports:
       - "8080:8080"
     networks:
       mazad-network:
     restart: on-failure
-    env_file: .env
   
   items-service:
     build: ./backend/item-service/
@@ -49,7 +50,7 @@ services:
     depends_on:
       - postgres
     ports:
-    - "${ITEMS_SERVICE_PORT}:${ITEMS_SERVICE_PORT}"
+    - "${ITEMS_SERVICE_PORT}:${ITEMS_SERVICE_PORT}" #this should be removed, accept connection only via Gateway api
     networks:
       mazad-network:
     restart: on-failure
@@ -64,8 +65,17 @@ services:
       - .env
     depends_on:
       - postgres
-    ports:
-      - "${AUTH_SERVER_PORT}:${AUTH_SERVER_PORT}"
+    environment:
+      - DB_URL=${DB_URL}
+      - AUTH_DB_NAME=${AUTH_DB_NAME}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - AUTH_SERVER_PORT=${AUTH_SERVER_PORT}
+      - AUTH_SECRET_KEY=${AUTH_SECRET_KEY}
+      - ACCESS_TOKEN_MIN=${ACCESS_TOKEN_MIN}
+      - REFRESH_TOKEN_DAY=${REFRESH_TOKEN_DAY}
+    # ports:
+    #   - "${AUTH_SERVER_PORT}:${AUTH_SERVER_PORT}"
     networks:
       mazad-network:
     restart: on-failure


### PR DESCRIPTION
- Add JWT dependencies (jjwt-api, jjwt-impl, jjwt-jackson).
- Create `JwtUtil` class for validating tokens and extracting claims (userId).
- Create `RouterValidator` to whitelist public endpoints (login, register, refresh).
- Implement `AuthenticationFilter` as a Global Filter to:
  - Intercept secured requests.
  - Validate Authorization header and JWT token.
  - Mutate requests to inject `X-User-Id` header before forwarding.
 - Add auth routing