### PR TITLE
feature(bidding): Bidding Service Containerization

### DIFF
--- a/backend/bidding-service/Dockerfile
+++ b/backend/bidding-service/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM maven:3.9.12-eclipse-temurin-21 AS builder
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Run stage
+FROM maven:3.9.12-eclipse-temurin-21 AS runner
+WORKDIR /app
+
+COPY --from=builder /app/target/*.jar spring-app.jar
+
+ENTRYPOINT ["java", "-jar", "spring-app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,15 @@ services:
       mazad-network:
     restart: on-failure
 
-
+  bidding-service:
+    image: bidding-service-img:1
+    build: ./backend/bidding-service/
+    container_name: bidding-service
+    depends_on:
+      - postgres
+    networks:
+      mazad-network:
+    restart: on-failure
 
   auth-service:
     build: ./backend/auth-service/
@@ -95,8 +103,6 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-
-
 
     networks:
       mazad-network:


### PR DESCRIPTION
- Added a multi-stage Dockerfile (`backend/bidding-service/Dockerfile`) for the `bidding-service`, enabling efficient building and packaging of the Spring application using Maven.

-  Integrated the `bidding-service` into the `docker-compose.yml` file, specifying build context, image name, container name, dependencies (on `postgres`), network configuration, and restart policy.