### PR TITLE
Update API endpoint for getting user wallet

### DIFF
--- a/frontend/src/api/userApi.ts
+++ b/frontend/src/api/userApi.ts
@@ -106,7 +106,7 @@ async function getApiKey(api: AxiosInstance): Promise<string | null> {
 
 async function getUserWallet(api: AxiosInstance): Promise<Wallet> {
     try {
-        const response = await api.get<Wallet>("/bids/wallet");
+        const response = await api.get<Wallet>("/wallet");
         return response.data;
     } catch (errors: any) {
         throw errors;


### PR DESCRIPTION
This pull request updates the wallet API endpoint used in the `getUserWallet` function to ensure it points to the correct resource.

- Changed the API endpoint in the `getUserWallet` function from `/bids/wallet` to `/wallet` in `frontend/src/api/userApi.ts`, ensuring the function retrieves wallet information from the correct endpoint.