### PR TITLE
Patch critical vulnerabilities in Spring Boot and Apache Tika

### DIFF
--- a/backend/upload-service/pom.xml
+++ b/backend/upload-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.0.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.mazad</groupId>
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
-			<version>2.9.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>io.minio</groupId>


### PR DESCRIPTION
- Bumped spring-boot-starter-parent from 4.0.1 to 4.0.4 to resolve High severity authentication bypass in Actuator endpoints.
- Bumped apache tika-core from 2.9.1 to 3.2.2 to patch Critical XXE (XML External Entity) injection vulnerability (CVE-2025-54988) preventing malicious PDF parsing exploits.